### PR TITLE
[Feat] 스터디 api

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,9 +1,11 @@
 from fastapi import APIRouter
 
 from app.api.auth import router as auth_router
+from app.api.study import router as study_router
 from app.api.user import router as user_router
 
 api_router = APIRouter()
 
 api_router.include_router(user_router, prefix="/user", tags=["User"])
 api_router.include_router(auth_router, prefix="/auth", tags=["Auth"])
+api_router.include_router(study_router, prefix="/study", tags=["Study"])

--- a/app/api/study.py
+++ b/app/api/study.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
 
 from app.core.security import get_token
-from app.crud.study import create_study_in_db
+from app.crud.study import create_study_in_db, get_study_paginate
 from app.crud.user import read_user_in_db
 from app.schemas.auth import Token
 from app.schemas.study import StudyBase
@@ -18,7 +18,20 @@ async def create_study(study_infos: StudyBase, token: Token = Depends(get_token)
     if user is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Could not validate credentials")
 
-    study_obj = await create_study_in_db(study_infos.title, study_infos.content, user)
+    study_obj = await create_study_in_db(
+        study_infos.title,
+        study_infos.content,
+        user,
+        max_participants=study_infos.max_participants,
+        expire_time=study_infos.expire_date,
+    )
     print(str(study_obj))
 
     return JSONResponse(content={"status": "success"})
+
+
+@router.get("/list")
+async def get_study_list(page: int = 1, limit: int = 10):
+    studies = get_study_paginate(page, limit)
+
+    return studies

--- a/app/api/study.py
+++ b/app/api/study.py
@@ -2,8 +2,13 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import JSONResponse
 
 from app.core.security import get_token
-from app.crud.study import create_study_in_db, get_study_paginate
+from app.crud.study import (
+    create_study_in_db,
+    get_study_by_id,
+    get_study_paginate,
+)
 from app.crud.user import read_user_in_db
+from app.models.study import Study
 from app.schemas.auth import Token
 from app.schemas.study import StudyBase
 
@@ -35,3 +40,22 @@ async def get_study_list(page: int = 1, limit: int = 10):
     studies = await get_study_paginate(page, limit)
 
     return studies
+
+
+@router.delete("/delete/{study_id}")
+async def delete_study(study_id: str, token: Token = Depends(get_token)):
+    study = await get_study_by_id(study_id)
+
+    user_email = token.email
+    user = await read_user_in_db(user_email)
+    await study.fetch_link(Study.owner)
+    print("study owner : ", study.owner)
+    if study is None:
+        raise HTTPException(status_code=400, detail="Could not find study with given id")
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Could not validate credentials")
+    if user_email != study.owner.email:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+
+    await study.delete()
+    return JSONResponse(content={"status": "success"})

--- a/app/api/study.py
+++ b/app/api/study.py
@@ -16,6 +16,7 @@ from app.crud.study import (
     update_study_in_db,
 )
 from app.crud.user import read_user_in_db
+from app.models.study import Study
 from app.schemas.auth import Token
 from app.schemas.study import StudyBase, StudyComment, StudyUpdate
 
@@ -44,6 +45,15 @@ async def create_study(study_infos: StudyBase, token: Token = Depends(get_token)
 async def get_study_list(page: int = 1, limit: int = 10):
     studies = await get_study_paginate(page, limit)
     return studies
+
+
+@router.get("/list/{study_id}")
+async def get_study_info(study_id: str) -> Study:
+    study = await get_study_by_id(study_id)
+    if study is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Could not find study with given id")
+    await study.fetch_all_links()
+    return study
 
 
 @router.delete("/delete/{study_id}")

--- a/app/api/study.py
+++ b/app/api/study.py
@@ -32,6 +32,6 @@ async def create_study(study_infos: StudyBase, token: Token = Depends(get_token)
 
 @router.get("/list")
 async def get_study_list(page: int = 1, limit: int = 10):
-    studies = get_study_paginate(page, limit)
+    studies = await get_study_paginate(page, limit)
 
     return studies

--- a/app/api/study.py
+++ b/app/api/study.py
@@ -156,12 +156,12 @@ async def approve_waiting_user(study_id: str, user_email: str, token: Token = De
 
     study_owner = await get_owner_from_study(study)
     participants_wait = await get_participants_wait_from_study(study)
-    if not await is_participants_left(study):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="No more participants can join this study")
     if token.email != study_owner.email:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="You are not owner of this study")
     if target_user not in participants_wait:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="User is not waiting to join this study")
+    if not await is_participants_left(study):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="No more participants can join this study")
 
     await move_waiter_to_participants(study, target_user)
     return JSONResponse(content={"status": "success"})
@@ -221,6 +221,7 @@ async def add_comment(study_id: str, comment_input: StudyComment, token: Token =
 @router.patch("/quit/{study_id}", response_model=StudyOutput)
 async def quit_study(study_id: str, token: Token = Depends(get_token)):
     """스터디 나가기"""
+    # TODO : 1명 남을때 나가기 방지 / 스터디 자동 삭제
     study = await get_study_by_id(study_id)
     target_user = await read_user_in_db(token.email)
 

--- a/app/api/study.py
+++ b/app/api/study.py
@@ -54,7 +54,10 @@ async def create_study(study_infos: StudyCreate, token: Token = Depends(get_toke
 # TODO : created_time순 정렬
 @router.get("/list", response_model=List[StudyOutputSimple])
 async def get_study_list(page: int = 1, limit: int = 10):
-    """스터디 목록 조회"""
+    """스터디 목록 조회
+
+    page로 스터디 목록 페이지 설정
+    limit로 페이지 별 스터디 개수 설정"""
     studies = await get_study_paginate(page, limit)
     return studies
 
@@ -92,8 +95,8 @@ async def delete_study(study_id: str, token: Token = Depends(get_token)):
     return JSONResponse(content={"status": "success"})
 
 
-@router.patch("/update/{study_id}")
-async def update_study(study_id: str, study_update: StudyUpdate, token: Token = Depends(get_token)) -> StudyUpdate:
+@router.patch("/update/{study_id}", response_model=StudyOutput)
+async def update_study(study_id: str, study_update: StudyUpdate, token: Token = Depends(get_token)):
     """스터디 정보 업데이트"""
     study = await get_study_by_id(study_id)
     if study is None:
@@ -112,6 +115,7 @@ async def update_study(study_id: str, study_update: StudyUpdate, token: Token = 
     if isinstance(study_updated, str):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=f"Study update failure: {study_updated}")
 
+    study_updated.fetch_all_links()
     return study_updated
 
 

--- a/app/api/study.py
+++ b/app/api/study.py
@@ -7,10 +7,11 @@ from app.crud.study import (
     get_owner_from_study,
     get_study_by_id,
     get_study_paginate,
+    is_participants_left,
 )
 from app.crud.user import read_user_in_db
 from app.schemas.auth import Token
-from app.schemas.study import StudyBase
+from app.schemas.study import StudyBase, StudyUpdate
 
 router = APIRouter()
 
@@ -58,4 +59,69 @@ async def delete_study(study_id: str, token: Token = Depends(get_token)):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
 
     await study.delete()
+    return JSONResponse(content={"status": "success"})
+
+
+@router.patch("/update/{study_id}")
+async def update_study(study_id: str, study_update: StudyUpdate, token: Token = Depends(get_token)):
+    # TODO
+    # 세부 구현 사항 논의 필요
+    study = await get_study_by_id(study_id)
+    # study_owner = await get_owner_from_study(study)
+
+    user_email = token.email
+    await read_user_in_db(user_email)
+
+    await get_owner_from_study(study)
+
+
+@router.patch("/join/{study_id}")
+async def join_study(study_id: str, token: Token = Depends(get_token)):
+    study = await get_study_by_id(study_id)
+    user_email = token.email
+    user = await read_user_in_db(user_email)
+
+    await study.fetch_all_links()
+
+    if study is None:
+        raise HTTPException(status_code=400, detail="Could not find study with given id")
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Could not validate credentials")
+    # if not await is_participants_left(study):
+    #     raise HTTPException(status_code=400, detail="No more participants can join this study")
+    if user in study.participants:
+        raise HTTPException(status_code=400, detail="User already joined this study")
+    if user in study.participants_wait:
+        raise HTTPException(status_code=400, detail="User already waiting to join this study")
+
+    study.participants_wait.append(user)
+    await study.replace()
+    return JSONResponse(content={"status": "success"})
+
+
+@router.patch("/approve/{study_id}")
+async def approve_waiting_user(study_id: str, user_email: str, token: Token = Depends(get_token)):
+    # TODO
+    # user_email body로 받기
+    study = await get_study_by_id(study_id)
+    study_owner = await get_owner_from_study(study)
+    user = await read_user_in_db(user_email)
+
+    await study.fetch_all_links()
+
+    if study is None:
+        raise HTTPException(status_code=400, detail="Could not find study with given id")
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Could not validate credentials")
+    if not await is_participants_left(study):
+        raise HTTPException(status_code=400, detail="No more participants can join this study")
+    if token.email != study_owner.email:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
+    if user not in study.participants_wait:
+        raise HTTPException(status_code=400, detail="User is not waiting to join this study")
+
+    study.participants_wait.remove(user)
+    study.participants.append(user)
+    study.cur_participants = len(study.participants)
+    await study.replace()
     return JSONResponse(content={"status": "success"})

--- a/app/api/study.py
+++ b/app/api/study.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.responses import JSONResponse
+
+from app.core.security import get_token
+from app.crud.study import create_study_in_db
+from app.crud.user import read_user_in_db
+from app.schemas.auth import Token
+from app.schemas.study import StudyBase
+
+router = APIRouter()
+
+
+@router.post("/create")
+async def create_study(study_infos: StudyBase, token: Token = Depends(get_token)):
+    user_email = token.email
+    user = await read_user_in_db(user_email)
+    print(user)
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Could not validate credentials")
+
+    study_obj = await create_study_in_db(study_infos.title, study_infos.content, user)
+    print(str(study_obj))
+
+    return JSONResponse(content={"status": "success"})

--- a/app/crud/study.py
+++ b/app/crud/study.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 from app.models import Study, User
 from app.models.study import CommentForm
+from app.schemas.study import StudyUpdate
 
 
 async def create_study_in_db(title, content, owner: User, max_participants: int, expire_time: datetime):
@@ -59,3 +60,19 @@ async def add_comment_to_study(study: Study, writer: User, comment: str):
     comment_obj = CommentForm(writer=writer, content=comment)
     study.comments.append(comment_obj)
     await study.replace()
+
+
+async def update_study_in_db(study_update: StudyUpdate, study: Study):
+    target_user = await User.get(study_update.owner_id)
+    if target_user is None:
+        return None
+
+    study.title = study_update.title
+    study.content = study_update.content
+    study.max_participants = study_update.max_participants
+    study.expire_time = study_update.expire_time
+    study.owner = target_user
+    study.status = study_update.status
+
+    await study.replace()
+    return study

--- a/app/crud/study.py
+++ b/app/crud/study.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from app.models import Study, User
+from app.models.study import CommentForm
 
 
 async def create_study_in_db(title, content, owner: User, max_participants: int, expire_time: datetime):
@@ -51,4 +52,10 @@ async def move_waiter_to_participants(study: Study, user: User):
     study.participants_wait.remove(user)
     study.participants.append(user)
     study.cur_participants = len(study.participants)
+    await study.replace()
+
+
+async def add_comment_to_study(study: Study, writer: User, comment: str):
+    comment_obj = CommentForm(writer=writer, content=comment)
+    study.comments.append(comment_obj)
     await study.replace()

--- a/app/crud/study.py
+++ b/app/crud/study.py
@@ -33,3 +33,10 @@ async def get_owner_from_study(study: Study):
 
 async def is_participants_left(study: Study):
     return study.cur_participants < study.max_participants
+
+
+async def move_waiter_to_participants(study: Study, user: User):
+    study.participants_wait.remove(user)
+    study.participants.append(user)
+    study.cur_participants = len(study.participants)
+    await study.replace()

--- a/app/crud/study.py
+++ b/app/crud/study.py
@@ -1,0 +1,50 @@
+from app.models import Study, User
+
+
+async def create_study_in_db(title, content, owner: User):
+    """Create Study"""
+    study = Study(title=title, content=content, owner=owner)
+
+    await study.create()
+
+    return study
+
+
+# async def create_user_in_db(email: EmailStr, password: str):
+#     """Create User"""
+#     user = User(email=email, password=password)
+
+#     await user.create()
+
+#     return user
+
+
+# async def read_user_in_db(email: EmailStr) -> User | None:
+#     """Get User by Email"""
+#     return await User.find_one(User.email == email)
+
+
+# async def update_user(new_user: UserUpdate, email: EmailStr) -> User | None:
+#     """Update User"""
+#     user = await User.find_one(User.email == email)
+#     if user is None:
+#         return None
+#     # TODO
+#     # for 문으로 수정 필요
+#     user.nick_name = new_user.nick_name
+#     user.submission = new_user.submission
+#     # try 쓸 필요 있나?
+#     try:
+#         await user.replace()
+#     except (ValueError, DocumentNotFound):
+#         print("Can't replace a non existing document")
+#     return user
+
+
+# async def delete_user(email: EmailStr) -> User | None:
+#     """Delete User"""
+#     user = await User.find_one(User.email == email)
+#     if user is None:
+#         return None
+#     await user.delete()
+#     return user

--- a/app/crud/study.py
+++ b/app/crud/study.py
@@ -31,6 +31,12 @@ async def get_owner_from_study(study: Study):
     return study.owner
 
 
+async def get_participants_wait_from_study(study: Study):
+    await study.fetch_link(Study.participants_wait)
+
+    return study.participants_wait
+
+
 async def is_participants_left(study: Study):
     return study.cur_participants < study.max_participants
 

--- a/app/crud/study.py
+++ b/app/crud/study.py
@@ -10,3 +10,10 @@ async def create_study_in_db(title, content, owner: User, max_participants: int,
     await study.create()
 
     return study
+
+
+async def get_study_paginate(page: int, limit: int):
+    start_idx = (page - 1) * limit
+    content = await Study.find().limit(limit).skip(start_idx).to_list()
+
+    return content

--- a/app/crud/study.py
+++ b/app/crud/study.py
@@ -29,3 +29,7 @@ async def get_owner_from_study(study: Study):
     await study.fetch_link(Study.owner)
 
     return study.owner
+
+
+async def is_participants_left(study: Study):
+    return study.cur_participants < study.max_participants

--- a/app/crud/study.py
+++ b/app/crud/study.py
@@ -1,15 +1,22 @@
+import random
 from datetime import datetime
-
-from beanie.odm.operators.update.array import Pull
 
 from app.models import Study, User
 from app.models.study import CommentForm
-from app.schemas.study import StudyUpdate
+from app.schemas.study import StudyCreate, StudyUpdate
 
 
-async def create_study_in_db(title, content, owner: User, max_participants: int, expire_time: datetime):
+async def create_study_in_db(study_infos: StudyCreate, owner: User):
     """Create Study"""
-    study = Study(title=title, content=content, owner=owner, max_participants=max_participants, expire_time=expire_time)
+    title = study_infos.title
+    content = study_infos.content
+    max_participants = study_infos.max_participants
+    expire_time = study_infos.expire_time
+    url = study_infos.url if study_infos.url else None
+
+    study = Study(
+        title=title, content=content, owner=owner, max_participants=max_participants, expire_time=expire_time, url=url
+    )
 
     await study.create()
 
@@ -35,6 +42,10 @@ async def get_owner_from_study(study: Study):
     return study.owner
 
 
+async def delete_study_from_db(study: Study):
+    await study.delete()
+
+
 async def get_participants_wait_from_study(study: Study):
     await study.fetch_link(Study.participants_wait)
 
@@ -47,11 +58,18 @@ async def get_likers_from_study(study: Study):
     return study.likes.likeID
 
 
-async def is_participants_left(study: Study):
+async def add_liker_to_study(study: Study, user: User):
+    study.likes.likeID.append(user)
+    study.likes.likeCount = len(study.likes.likeID)
+    await study.replace()
+
+
+async def is_participants_left(study: Study) -> bool:
     return study.cur_participants < study.max_participants
 
 
 async def move_waiter_to_participants(study: Study, user: User):
+    # TODO : remove -> pull?
     study.participants_wait.remove(user)
     study.participants.append(user)
     study.cur_participants = len(study.participants)
@@ -64,10 +82,9 @@ async def add_comment_to_study(study: Study, writer: User, comment: str):
     await study.replace()
 
 
-async def update_study_in_db(study_update: StudyUpdate, study: Study):
+async def update_study_in_db(study_update: StudyUpdate, study: Study) -> Study | str:
+    await study.fetch_all_links()
     target_user = await User.get(study_update.owner_id)
-    if target_user is None:
-        return None
 
     study.title = study_update.title
     study.content = study_update.content
@@ -75,25 +92,38 @@ async def update_study_in_db(study_update: StudyUpdate, study: Study):
     study.expire_time = study_update.expire_time
     study.owner = target_user
     study.status = study_update.status
+    study.url = study_update.url
+
+    # print(study_update.expire_time.tzinfo, datetime.now().tzinfo)
+    tz = study_update.expire_time.tzinfo
+
+    if target_user is None:
+        return "Can't find user with given id."
+    if study_update.max_participants < study.cur_participants:
+        return "Can't update max_participants to lower than current participants."
+    if study_update.expire_time < datetime.now(tz):
+        return "Can't update expire_time to lower than current time."
+    if study.expire_time < datetime.now(tz) and study_update.status == "open":
+        return "Can't open expired study."
+    if target_user not in study.participants:
+        return "Can't update owner to non-participant."
 
     await study.replace()
     return study
 
 
+async def add_user_to_waitlist(study: Study, user: User):
+    study.participants_wait.append(user)
+    await study.replace()
+
+
 async def remove_user_from_study(study: Study, user: User):
-    await study.update(Pull({"participants": {"$id": user.id}}))
+    await study.fetch_link(Study.owner)
+    study.participants.remove(user)
+    if study.owner == user:
+        study.owner = random.choice(study.participants)
+    study.cur_participants = len(study.participants)
+
+    await study.replace()
+
     return study
-
-    # Pull({"Study.participants": {"$i 9d": user.id}})
-    # study.cur_participants = len(study.participants)
-    # await study.update_all()
-
-    """
-    db.study.update(
-    { _id: ObjectId("65448e833980d3a535c92a91") },
-    { $pull:
-        { participants:
-            { $id: ObjectId("650ed3282e816d7bde32fe45") }
-        }
-    } )
-    """

--- a/app/crud/study.py
+++ b/app/crud/study.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+from beanie.odm.operators.update.array import Pull
+
 from app.models import Study, User
 from app.models.study import CommentForm
 from app.schemas.study import StudyUpdate
@@ -76,3 +78,22 @@ async def update_study_in_db(study_update: StudyUpdate, study: Study):
 
     await study.replace()
     return study
+
+
+async def remove_user_from_study(study: Study, user: User):
+    await study.update(Pull({"participants": {"$id": user.id}}))
+    return study
+
+    # Pull({"Study.participants": {"$i 9d": user.id}})
+    # study.cur_participants = len(study.participants)
+    # await study.update_all()
+
+    """
+    db.study.update(
+    { _id: ObjectId("65448e833980d3a535c92a91") },
+    { $pull:
+        { participants:
+            { $id: ObjectId("650ed3282e816d7bde32fe45") }
+        }
+    } )
+    """

--- a/app/crud/study.py
+++ b/app/crud/study.py
@@ -1,50 +1,12 @@
+from datetime import datetime
+
 from app.models import Study, User
 
 
-async def create_study_in_db(title, content, owner: User):
+async def create_study_in_db(title, content, owner: User, max_participants: int, expire_time: datetime):
     """Create Study"""
-    study = Study(title=title, content=content, owner=owner)
+    study = Study(title=title, content=content, owner=owner, max_participants=max_participants, expire_time=expire_time)
 
     await study.create()
 
     return study
-
-
-# async def create_user_in_db(email: EmailStr, password: str):
-#     """Create User"""
-#     user = User(email=email, password=password)
-
-#     await user.create()
-
-#     return user
-
-
-# async def read_user_in_db(email: EmailStr) -> User | None:
-#     """Get User by Email"""
-#     return await User.find_one(User.email == email)
-
-
-# async def update_user(new_user: UserUpdate, email: EmailStr) -> User | None:
-#     """Update User"""
-#     user = await User.find_one(User.email == email)
-#     if user is None:
-#         return None
-#     # TODO
-#     # for 문으로 수정 필요
-#     user.nick_name = new_user.nick_name
-#     user.submission = new_user.submission
-#     # try 쓸 필요 있나?
-#     try:
-#         await user.replace()
-#     except (ValueError, DocumentNotFound):
-#         print("Can't replace a non existing document")
-#     return user
-
-
-# async def delete_user(email: EmailStr) -> User | None:
-#     """Delete User"""
-#     user = await User.find_one(User.email == email)
-#     if user is None:
-#         return None
-#     await user.delete()
-#     return user

--- a/app/crud/study.py
+++ b/app/crud/study.py
@@ -23,3 +23,9 @@ async def get_study_by_id(study_id: str):
     content = await Study.get(study_id)
 
     return content
+
+
+async def get_owner_from_study(study: Study):
+    await study.fetch_link(Study.owner)
+
+    return study.owner

--- a/app/crud/study.py
+++ b/app/crud/study.py
@@ -37,6 +37,12 @@ async def get_participants_wait_from_study(study: Study):
     return study.participants_wait
 
 
+async def get_likers_from_study(study: Study):
+    await study.fetch_link(Study.likes.likeID)
+
+    return study.likes.likeID
+
+
 async def is_participants_left(study: Study):
     return study.cur_participants < study.max_participants
 

--- a/app/crud/study.py
+++ b/app/crud/study.py
@@ -103,7 +103,7 @@ async def update_study_in_db(study_update: StudyUpdate, study: Study) -> Study |
         return "Can't update max_participants to lower than current participants."
     if study_update.expire_time < datetime.now(tz):
         return "Can't update expire_time to lower than current time."
-    if study.expire_time < datetime.now(tz) and study_update.status == "open":
+    if study.expire_time < datetime.now(tz) and study_update.status == "open":  # Not tested
         return "Can't open expired study."
     if target_user not in study.participants:
         return "Can't update owner to non-participant."

--- a/app/crud/study.py
+++ b/app/crud/study.py
@@ -17,3 +17,9 @@ async def get_study_paginate(page: int, limit: int):
     content = await Study.find().limit(limit).skip(start_idx).to_list()
 
     return content
+
+
+async def get_study_by_id(study_id: str):
+    content = await Study.get(study_id)
+
+    return content

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,3 +1,4 @@
+from app.models.study import Study
 from app.models.user import User
 
-__all_model__ = [User]
+__all_model__ = [User, Study]

--- a/app/models/study.py
+++ b/app/models/study.py
@@ -14,6 +14,11 @@ class CommentForm(BaseModel):
     content: str
 
 
+class Likes(BaseModel):
+    likeCount: int = 0
+    likeID: List[Link[User]] = []
+
+
 class statusEnum(str, Enum):
     """상태를 나타내는 enumerate datatype
 
@@ -38,7 +43,7 @@ class Study(Document):
     comments: Optional[List[CommentForm]] = None
     max_participants: int = Field(gt=1)
     cur_participants: int = 0
-    likes: int = Field(default=0)
+    likes: Likes = Likes()
     url: Optional[HttpUrl] = None
     created_time: datetime = Field(default_factory=datetime.now)
     expire_time: datetime

--- a/app/models/study.py
+++ b/app/models/study.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import List, Optional
 
 from beanie import Document, Link
-from pydantic import BaseModel, Field, HttpUrl
+from pydantic import BaseModel, Field
 from pydantic.functional_validators import model_validator
 
 from .user import User
@@ -19,12 +19,12 @@ class Likes(BaseModel):
     likeID: List[Link[User]] = []
 
 
-class statusEnum(str, Enum):
+class StudyStatus(str, Enum):
     """상태를 나타내는 enumerate datatype
 
     closed: 스터디가 종료됨
     open: 스터디 모집중
-    canceled: 인원 부족, 팀장에 의한 취소 등으로 스터디가 종료됨
+    canceled: 인원 부족(시간 초과), 팀장에 의한 취소 등으로 스터디가 종료됨
     """
 
     closed = "closed"
@@ -35,6 +35,8 @@ class statusEnum(str, Enum):
 class Study(Document):
     """User DB representation"""
 
+    # TODO : replace() override후 cur_participants 업데이트하기
+
     owner: Link[User]
     title: str
     content: str
@@ -44,10 +46,10 @@ class Study(Document):
     max_participants: int = Field(gt=1)
     cur_participants: int = 0
     likes: Likes = Likes()
-    url: Optional[HttpUrl] = None
+    url: Optional[str] = None
     created_time: datetime = Field(default_factory=datetime.now)
     expire_time: datetime
-    status: statusEnum = statusEnum.open
+    status: StudyStatus = StudyStatus.open
 
     @model_validator(mode="after")
     def check_expire_gt_than_created(self) -> "Study":

--- a/app/models/study.py
+++ b/app/models/study.py
@@ -40,7 +40,7 @@ class Study(Document):
     content: str
     participants: List[Link[User]] = Field(unique=True, default=[])
     participants_wait: List[Link[User]] = Field(unique=True, default=[])
-    comments: Optional[List[CommentForm]] = None
+    comments: List[CommentForm] = []
     max_participants: int = Field(gt=1)
     cur_participants: int = 0
     likes: Likes = Likes()

--- a/app/models/study.py
+++ b/app/models/study.py
@@ -53,7 +53,6 @@ class Study(Document):
     async def create(self, *args, **kwargs):
         self.participants.append(self.owner)
         self.cur_participants = len(self.participants)
-        self._validate_after_creation = True
         await super().create(*args, **kwargs)
 
     class Settings:

--- a/app/models/study.py
+++ b/app/models/study.py
@@ -33,8 +33,8 @@ class Study(Document):
     owner: Link[User]
     title: str
     content: str
-    participants: List[Link[User]] = []
-    participants_wait: List[Link[User]] = []
+    participants: List[Link[User]] = Field(unique=True, default=[])
+    participants_wait: List[Link[User]] = Field(unique=True, default=[])
     comments: Optional[List[CommentForm]] = None
     max_participants: int = Field(gt=1)
     cur_participants: int = 0

--- a/app/models/study.py
+++ b/app/models/study.py
@@ -1,0 +1,14 @@
+from beanie import Document, Link
+
+from . import User
+
+
+class Study(Document):
+    """User DB representation"""
+
+    owner: Link[User]
+    title: str
+    content: str
+
+    class Settings:
+        name = "study"

--- a/app/models/study.py
+++ b/app/models/study.py
@@ -1,6 +1,30 @@
-from beanie import Document, Link
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
 
-from . import User
+from beanie import Document, Link
+from pydantic import BaseModel, Field, HttpUrl
+from pydantic.functional_validators import model_validator
+
+from .user import User
+
+
+class CommentForm(BaseModel):
+    writer: Link[User]
+    content: str
+
+
+class statusEnum(str, Enum):
+    """상태를 나타내는 enumerate datatype
+
+    closed: 스터디가 종료됨
+    open: 스터디 모집중
+    canceled: 인원 부족, 팀장에 의한 취소 등으로 스터디가 종료됨
+    """
+
+    closed = "closed"
+    open = "opened"
+    canceled = "canceled"
 
 
 class Study(Document):
@@ -9,6 +33,28 @@ class Study(Document):
     owner: Link[User]
     title: str
     content: str
+    participants: List[Link[User]] = []
+    participants_wait: List[Link[User]] = []
+    comments: Optional[List[CommentForm]] = None
+    max_participants: int = Field(gt=1)
+    cur_participants: int = 0
+    likes: int = Field(default=0)
+    url: Optional[HttpUrl] = None
+    created_time: datetime = Field(default_factory=datetime.now)
+    expire_time: datetime
+    status: statusEnum = statusEnum.open
+
+    @model_validator(mode="after")
+    def check_expire_gt_than_created(self) -> "Study":
+        if self.created_time >= self.expire_time:
+            raise ValueError("expire_time must be greater than created_time")
+        return self
+
+    async def create(self, *args, **kwargs):
+        self.participants.append(self.owner)
+        self.cur_participants = len(self.participants)
+        self._validate_after_creation = True
+        await super().create(*args, **kwargs)
 
     class Settings:
         name = "study"

--- a/app/models/study.py
+++ b/app/models/study.py
@@ -15,8 +15,8 @@ class CommentForm(BaseModel):
 
 
 class Likes(BaseModel):
-    likeCount: int = 0
-    likeID: List[Link[User]] = []
+    like_count: int = 0
+    like_ID: List[Link[User]] = []
 
 
 class StudyStatus(str, Enum):

--- a/app/schemas/study.py
+++ b/app/schemas/study.py
@@ -1,8 +1,12 @@
+from datetime import datetime
+
 from pydantic import BaseModel
 
 
 class StudyBase(BaseModel):
     title: str
     content: str
+    max_participants: int
+    expire_date: datetime
 
     model_config = {"json_schema_extra": {"examples": [{"title": "test_title", "content": "test_content"}]}}

--- a/app/schemas/study.py
+++ b/app/schemas/study.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class StudyBase(BaseModel):
+    title: str
+    content: str
+
+    model_config = {"json_schema_extra": {"examples": [{"title": "test_title", "content": "test_content"}]}}

--- a/app/schemas/study.py
+++ b/app/schemas/study.py
@@ -10,7 +10,7 @@ class StudyBase(BaseModel):
     title: str
     content: str
     max_participants: int
-    expire_date: datetime
+    expire_time: datetime
 
     model_config = {
         "json_schema_extra": {
@@ -19,7 +19,7 @@ class StudyBase(BaseModel):
                     "title": "test_title",
                     "content": "test_content",
                     "max_participants": 10,
-                    "expire_date": str(datetime.now()),
+                    "expire_time": str(datetime.now()),
                 }
             ]
         }

--- a/app/schemas/study.py
+++ b/app/schemas/study.py
@@ -12,7 +12,18 @@ class StudyBase(BaseModel):
     max_participants: int
     expire_date: datetime
 
-    model_config = {"json_schema_extra": {"examples": [{"title": "test_title", "content": "test_content"}]}}
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "title": "test_title",
+                    "content": "test_content",
+                    "max_participants": 10,
+                    "expire_date": str(datetime.now()),
+                }
+            ]
+        }
+    }
 
 
 class StudyUpdate(BaseModel):

--- a/app/schemas/study.py
+++ b/app/schemas/study.py
@@ -1,16 +1,18 @@
 from datetime import datetime
+from typing import Optional
 
 from beanie import PydanticObjectId
 from pydantic import BaseModel
 
-from app.models.study import statusEnum
+from app.models.study import StudyStatus
 
 
-class StudyBase(BaseModel):
+class StudyCreate(BaseModel):
     title: str
     content: str
     max_participants: int
     expire_time: datetime
+    url: Optional[str] = None
 
     model_config = {
         "json_schema_extra": {
@@ -20,6 +22,7 @@ class StudyBase(BaseModel):
                     "content": "test_content",
                     "max_participants": 10,
                     "expire_time": str(datetime.now()),
+                    "url": "",
                 }
             ]
         }
@@ -32,7 +35,8 @@ class StudyUpdate(BaseModel):
     max_participants: int
     expire_time: datetime
     owner_id: PydanticObjectId
-    status: statusEnum
+    status: StudyStatus
+    url: Optional[str]
 
 
 class StudyComment(BaseModel):

--- a/app/schemas/study.py
+++ b/app/schemas/study.py
@@ -1,6 +1,9 @@
 from datetime import datetime
 
+from beanie import PydanticObjectId
 from pydantic import BaseModel
+
+from ..models.study import statusEnum
 
 
 class StudyBase(BaseModel):
@@ -10,3 +13,12 @@ class StudyBase(BaseModel):
     expire_date: datetime
 
     model_config = {"json_schema_extra": {"examples": [{"title": "test_title", "content": "test_content"}]}}
+
+
+class StudyUpdate(BaseModel):
+    title: str
+    content: str
+    max_participants: int
+    expire_date: datetime
+    owner_id: PydanticObjectId
+    status: statusEnum

--- a/app/schemas/study.py
+++ b/app/schemas/study.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from beanie import PydanticObjectId
 from pydantic import BaseModel
 
-from ..models.study import statusEnum
+from app.models.study import statusEnum
 
 
 class StudyBase(BaseModel):
@@ -33,3 +33,7 @@ class StudyUpdate(BaseModel):
     expire_date: datetime
     owner_id: PydanticObjectId
     status: statusEnum
+
+
+class StudyComment(BaseModel):
+    comment: str

--- a/app/schemas/study.py
+++ b/app/schemas/study.py
@@ -30,7 +30,7 @@ class StudyUpdate(BaseModel):
     title: str
     content: str
     max_participants: int
-    expire_date: datetime
+    expire_time: datetime
     owner_id: PydanticObjectId
     status: statusEnum
 

--- a/app/schemas/study.py
+++ b/app/schemas/study.py
@@ -9,6 +9,29 @@ from app.models.user import User
 from app.schemas.user import UserOut
 
 
+# 스터디 출력용 field
+class StudyCommentOut(BaseModel):
+    """스터디 댓글(작성자, 내용)"""
+
+    writer: UserOut
+    content: str
+
+
+class LikesOut(BaseModel):
+    """스터디 좋아요 정보(좋아요 수만 출력)"""
+
+    likeCount: int
+
+
+class StudyUserOutput(BaseModel):
+    """스터디 관련 User 출력(id, email, nick_name)"""
+
+    id: PydanticObjectId
+    email: str
+    nick_name: str
+
+
+# 스터디 입,출력 schema
 class StudyCreate(BaseModel):
     title: str
     content: str
@@ -46,13 +69,6 @@ class StudyComment(BaseModel):
 
 
 class StudyOutputSimple(BaseModel):
-    class StudyCommentOut(BaseModel):
-        writer: UserOut
-        content: str
-
-    class LikesOut(BaseModel):
-        likeCount: int
-
     id: PydanticObjectId
     owner: Link[User]
     title: str
@@ -68,11 +84,6 @@ class StudyOutputSimple(BaseModel):
 
 
 class StudyOutput(StudyOutputSimple):
-    class StudyUserOutput(BaseModel):
-        id: PydanticObjectId
-        email: str
-        nick_name: str
-
     owner: StudyUserOutput
     participants: List[StudyUserOutput]
     participants_wait: List[StudyUserOutput]

--- a/app/schemas/study.py
+++ b/app/schemas/study.py
@@ -1,10 +1,12 @@
 from datetime import datetime
-from typing import Optional
+from typing import List, Optional
 
-from beanie import PydanticObjectId
+from beanie import Link, PydanticObjectId
 from pydantic import BaseModel
 
 from app.models.study import StudyStatus
+from app.models.user import User
+from app.schemas.user import UserOut
 
 
 class StudyCreate(BaseModel):
@@ -41,3 +43,36 @@ class StudyUpdate(BaseModel):
 
 class StudyComment(BaseModel):
     comment: str
+
+
+class StudyOutputSimple(BaseModel):
+    class StudyCommentOut(BaseModel):
+        writer: UserOut
+        content: str
+
+    class LikesOut(BaseModel):
+        likeCount: int
+
+    id: PydanticObjectId
+    owner: Link[User]
+    title: str
+    content: str
+    comments: List[StudyCommentOut]
+    max_participants: int
+    cur_participants: int
+    likes: LikesOut
+    url: Optional[str]
+    created_time: datetime
+    expire_time: datetime
+    status: StudyStatus
+
+
+class StudyOutput(StudyOutputSimple):
+    class StudyUserOutput(BaseModel):
+        id: PydanticObjectId
+        email: str
+        nick_name: str
+
+    owner: StudyUserOutput
+    participants: List[StudyUserOutput]
+    participants_wait: List[StudyUserOutput]


### PR DESCRIPTION
## 개요
스터디 api 추가

## 변경 사항
* router에 study url 추가
* `api/study.py`, `crud/study.py`에 스터디 생성, 조회, 삭제, 업데이트, 참가, 참가 승인, 좋아요 추가, 댓글 추가, 스터디 나가기 구현
* 스터디 DB 모델 추가
* 스터디 생성, 업데이트 입력 scheme, 스터디 출력 scheme 추가

## 코드 리뷰시 참고사항


## 테스트 결과
* 수동 테스트 시 이상 없음(이후 pytest 코드 추가 예정)

## 연결된 이슈
Closes: #86 